### PR TITLE
Fix exceeding Windows max command-line length with -filter_script, optional --win to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ options:
   --threads-encoding <int>
                         ffmpeg encoding options -threads value
   --threads <int>       ffmpeg -threads value (for both global options and encoding)
+  --win                 Use Windows-compatible multi-step processing (try this if you encounter errors on Windows, especially command-line length errors)
 ```
 
 ### Docker

--- a/src/cleanvid/cleanvid.py
+++ b/src/cleanvid/cleanvid.py
@@ -9,10 +9,10 @@ import json
 import os
 import shutil
 import sys
+import subprocess
 import re
 import pysrt
 import delegator
-import tempfile # Added for temporary files
 from datetime import datetime
 from subliminal import *
 from babelfish import Language
@@ -195,15 +195,6 @@ def UTF8Convert(fileSpec, universalEndline=True):
     with open(fileSpec, 'wb') as f:
         f.write(raw)
 
-# Helper function to run ffmpeg and check results
-def run_ffmpeg_command(command, error_message_prefix="ffmpeg command failed"):
-    print(f"Running ffmpeg command:\n{command}") # Log the command
-    result = delegator.run(command, block=True)
-    if result.return_code != 0:
-        print(f"ffmpeg stderr:\n{result.err}")
-        raise ValueError(f"{error_message_prefix}: {result.err}")
-    print("ffmpeg command completed successfully.")
-    return result
 
 #################################################################################
 class VidCleaner(object):
@@ -323,11 +314,8 @@ class VidCleaner(object):
                 os.remove(self.jsonFileSpec)
         if os.path.isfile(self.tmpSubsFileSpec):
             os.remove(self.tmpSubsFileSpec)
-        if os.path.isfile(self.assSubsFileSpec) and not self.hardCode: # Keep ASS if hardcoding succeeded
-             try:
-                 os.remove(self.assSubsFileSpec)
-             except OSError:
-                 pass # Ignore error if file is gone
+        if os.path.isfile(self.assSubsFileSpec):
+            os.remove(self.assSubsFileSpec)
 
     ######## CreateCleanSubAndMuteList #################################################
     def CreateCleanSubAndMuteList(self):
@@ -499,8 +487,6 @@ class VidCleaner(object):
                 + timePairPeek[0].second
                 + (timePairPeek[0].microsecond / 1000000.0)
             )
-            # Build filter graph components for audio filtering
-            # Using afade for smoother transitions (original logic)
             self.muteTimeList.append(
                 "afade=enable='between(t,"
                 + format(lineStart, '.3f')
@@ -508,18 +494,17 @@ class VidCleaner(object):
                 + format(lineEnd, '.3f')
                 + ")':t=out:st="
                 + format(lineStart, '.3f')
-                + ":d=10ms" # Mute section (fade out)
+                + ":d=10ms"
             )
             self.muteTimeList.append(
                 "afade=enable='between(t,"
                 + format(lineEnd, '.3f')
                 + ","
-                + format(lineStartPeek, '.3f') # Use peek for fade-in start
+                + format(lineStartPeek, '.3f')
                 + ")':t=in:st="
                 + format(lineEnd, '.3f')
-                + ":d=10ms" # Unmute section (fade in)
+                + ":d=10ms"
             )
-
             if self.edl:
                 edlLines.append(f"{format(lineStart, '.1f')}\t{format(lineEnd, '.3f')}\t1")
             if plexDict:
@@ -539,332 +524,105 @@ class VidCleaner(object):
 
     ######## MultiplexCleanVideo ###################################################
     def MultiplexCleanVideo(self):
-        temp_files_to_clean = [] # List to hold paths of temp files for cleanup
-        temp_filter_filepath = None # Keep this separate as it's handled slightly differently
-        audioStreams = None # Define audioStreams in the broader scope
+        # if we're don't *have* to generate a new video file, don't
+        # we need to generate a video file if any of the following are true:
+        # - we were explicitly asked to re-encode
+        # - we are hard-coding (burning) subs
+        # - we are embedding a subtitle stream
+        # - we are not doing "subs only" or EDL mode and there more than zero mute sections
+        if (
+            self.reEncodeVideo
+            or self.reEncodeAudio
+            or self.hardCode
+            or self.embedSubs
+            or ((not self.subsOnly) and (len(self.muteTimeList) > 0))
+        ):
+            if self.reEncodeVideo or self.hardCode:
+                if self.hardCode and os.path.isfile(self.cleanSubsFileSpec):
+                    self.assSubsFileSpec = self.cleanSubsFileSpec + '.ass'
+                    subConvCmd = f"ffmpeg -hide_banner -nostats -loglevel error -y -i {self.cleanSubsFileSpec} {self.assSubsFileSpec}"
+                    subConvResult = delegator.run(subConvCmd, block=True)
+                    if (subConvResult.return_code == 0) and os.path.isfile(self.assSubsFileSpec):
+                        videoArgs = f"{self.vParams} -vf \"ass={self.assSubsFileSpec}\""
+                    else:
+                        print(subConvCmd)
+                        print(subConvResult.err)
+                        raise ValueError(f'Could not process {self.cleanSubsFileSpec}')
+                else:
+                    videoArgs = self.vParams
+            else:
+                videoArgs = "-c:v copy"
 
-        try:
-            # Determine if video processing is needed (existing logic)
-            needs_processing = (
-                self.reEncodeVideo
-                or self.reEncodeAudio
-                or self.hardCode
-                or self.embedSubs
-                or ((not self.subsOnly) and (len(self.muteTimeList) > 0)) # Check original muteTimeList length
+            audioStreamOnlyIndex = 0
+            if audioStreams := GetAudioStreamsInfo(self.inputVidFileSpec).get('streams', []):
+                if len(audioStreams) > 0:
+                    if self.audioStreamIdx is None:
+                        if len(audioStreams) == 1:
+                            if 'index' in audioStreams[0]:
+                                self.audioStreamIdx = audioStreams[0]['index']
+                            else:
+                                raise ValueError(f'Could not determine audio stream index for {self.inputVidFileSpec}')
+                        else:
+                            raise ValueError(
+                                f'Multiple audio streams, specify audio stream index with --audio-stream-index'
+                            )
+                    elif any(stream.get('index', -1) == self.audioStreamIdx for stream in audioStreams):
+                        audioStreamOnlyIndex = next(
+                            (
+                                i
+                                for i, stream in enumerate(audioStreams)
+                                if stream.get('index', -1) == self.audioStreamIdx
+                            ),
+                            0,
+                        )
+                    else:
+                        raise ValueError(
+                            f'Audio stream index {self.audioStreamIdx} is invalid for {self.inputVidFileSpec}'
+                        )
+                else:
+                    raise ValueError(f'No audio streams found in {self.inputVidFileSpec}')
+            else:
+                raise ValueError(f'Could not determine audio streams in {self.inputVidFileSpec}')
+            self.aParams = re.sub(r"-c:a(\s+)", rf"-c:a:{str(audioStreamOnlyIndex)}\1", self.aParams)
+            audioUnchangedMapList = ' '.join(
+                f'-map 0:a:{i}' if i != audioStreamOnlyIndex else '' for i in range(len(audioStreams))
             )
 
-            if not needs_processing:
-                self.unalteredVideo = True
-                print("No video/audio processing required based on options.")
-                return # Exit early if no processing needed
-
-            # --- Determine audio stream index ---
-            audioStreamOnlyIndex = 0 # Default to first stream if index not specified/found
-            audioStreams = GetAudioStreamsInfo(self.inputVidFileSpec)
-            if not audioStreams or 'streams' not in audioStreams or not audioStreams['streams']:
-                 raise ValueError(f'Could not determine audio streams in {self.inputVidFileSpec}')
-
-            actual_streams = audioStreams['streams']
-            if self.audioStreamIdx is None:
-                if len(actual_streams) == 1:
-                    if 'index' in actual_streams[0]:
-                        self.audioStreamIdx = actual_streams[0]['index']
-                        # Find the 0-based index for mapping
-                        audioStreamOnlyIndex = next((i for i, s in enumerate(actual_streams) if s.get('index') == self.audioStreamIdx), 0)
-                    else:
-                        raise ValueError(f'Could not determine audio stream index for {self.inputVidFileSpec}')
-                else:
-                    raise ValueError(
-                        f'Multiple audio streams ({len(actual_streams)} found), specify audio stream index with --audio-stream-index'
-                    )
-            elif any(stream.get('index', -1) == self.audioStreamIdx for stream in actual_streams):
-                 # Find the 0-based index for mapping
-                 audioStreamOnlyIndex = next((i for i, s in enumerate(actual_streams) if s.get('index') == self.audioStreamIdx), 0)
-            else:
-                raise ValueError(
-                    f'Audio stream index {self.audioStreamIdx} is invalid for {self.inputVidFileSpec}'
-                )
-
-            # Apply stream index to aParams if needed (original logic modified)
-            # This might add complexity if aParams already has stream specifiers.
-            # Let's simplify: we'll handle codec selection explicitly later.
-            # self.aParams = re.sub(r"-c:a(\s+)", rf"-c:a:{str(audioStreamOnlyIndex)}\1", self.aParams)
-            print(f"Selected audio stream: Input Index={self.audioStreamIdx}, FFmpeg Map Index=0:a:{audioStreamOnlyIndex}")
-
-
-            # --- Determine if audio filtering is needed ---
-            # Note: muteTimeList is populated in CreateCleanSubAndMuteList
             if self.aDownmix and HasAudioMoreThanStereo(self.inputVidFileSpec):
-                # Prepend downmix filter if needed *before* checking length
-                if AUDIO_DOWNMIX_FILTER not in self.muteTimeList: # Avoid duplicates
-                    self.muteTimeList.insert(0, AUDIO_DOWNMIX_FILTER)
-
-            audio_filtering_active = (not self.subsOnly) and (len(self.muteTimeList) > 0)
-
-            # --- Main Processing Logic ---
-            if audio_filtering_active:
-                print("Audio filtering is active. Using multi-step ffmpeg process.")
-
-                # == Step 1: Split Streams ==
-                print("Step 1: Splitting video and audio streams...")
-
-                # Create temporary files (manage deletion manually in finally)
-                # Use mkv as intermediate container for video, wav for raw audio
-                temp_video_file = tempfile.NamedTemporaryFile(suffix=".mkv", delete=False)
-                temp_raw_audio_file = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
-                temp_video_filepath = temp_video_file.name
-                temp_raw_audio_filepath = temp_raw_audio_file.name
-                temp_video_file.close() # Close handles immediately
-                temp_raw_audio_file.close()
-                temp_files_to_clean.extend([temp_video_filepath, temp_raw_audio_filepath])
-                print(f"  Temp video file: {temp_video_filepath}")
-                print(f"  Temp raw audio file: {temp_raw_audio_filepath}")
-
-                # 1a: Extract video (copy)
-                ffmpeg_split_video_cmd = (
-                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
-                    f"{'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} "
-                    f"-i \"{self.inputVidFileSpec}\" "
-                    f"-map 0:v -c:v copy -dn -sn " # Copy video, drop data/subs
-                    f"\"{temp_video_filepath}\""
-                )
-                run_ffmpeg_command(ffmpeg_split_video_cmd, "Failed to split video stream")
-
-                # 1b: Extract and decode audio to WAV
-                ffmpeg_split_audio_cmd = (
-                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
-                    f"{'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} "
-                    f"-i \"{self.inputVidFileSpec}\" "
-                    f"-map 0:a:{audioStreamOnlyIndex} -c:a pcm_s16le " # Decode to WAV
-                    f"\"{temp_raw_audio_filepath}\""
-                )
-                run_ffmpeg_command(ffmpeg_split_audio_cmd, "Failed to split and decode audio stream")
-
-                # == Step 2: Filter Audio ==
-                print("Step 2: Filtering audio stream...")
-
-                # Create filter script file
-                filter_graph_content = ",".join(self.muteTimeList)
-                temp_filter_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt', encoding='utf-8')
-                temp_filter_filepath = temp_filter_file.name # Store path for cleanup
-                # Filtergraph for single WAV input doesn't need stream specifiers like [0:a:0]
-                # It implicitly operates on the input stream.
-                temp_filter_file.write(f"{filter_graph_content}")
-                temp_filter_file.close()
-                temp_files_to_clean.append(temp_filter_filepath) # Add filter script for cleanup
-                print(f"  Temp filter script: {temp_filter_filepath}")
-
-
-                # Determine output audio parameters (remove stream specifiers if present)
-                # Use default codec if 'copy' is specified, otherwise use provided params
-                current_aParams = self.aParams
-                default_codec_match = re.search(r'-c:a\s+(\S+)', AUDIO_DEFAULT_PARAMS)
-                default_codec = default_codec_match.group(1) if default_codec_match else 'aac'
-                output_audio_codec = default_codec # Default to AAC
-
-                # Try to extract codec and other params from self.aParams
-                # Remove any stream specifiers first
-                current_aParams = re.sub(r'-c:a:\d+\s+', '-c:a ', current_aParams)
-                current_aParams = re.sub(r'-codec:a:\d+\s+', '-codec:a ', current_aParams)
-
-                codec_match = re.search(r'-(?:c|codec):a\s+(\S+)', current_aParams)
-                if codec_match:
-                    specified_codec = codec_match.group(1)
-                    if specified_codec.lower() != 'copy':
-                        output_audio_codec = specified_codec
-                        # Remove the codec part to keep other params like bitrate, etc.
-                        current_aParams = re.sub(r'\s*-(?:c|codec):a\s+\S+', '', current_aParams).strip()
-                    else:
-                        # If 'copy' was specified, just use default codec and ignore other params in self.aParams for this step
-                         current_aParams = re.sub(r'\s*-(?:c|codec):a\s+copy', '', current_aParams).strip()
-                else:
-                    # No codec specified in aParams, use default
-                    output_audio_codec = default_codec
-                    current_aParams = "" # Clear params if only default codec is used
-
-                # Determine filtered audio file extension based on codec
-                filtered_audio_suffix = f".{output_audio_codec}"
-                if output_audio_codec == 'aac': filtered_audio_suffix = '.m4a'
-                elif output_audio_codec == 'ac3': filtered_audio_suffix = '.ac3'
-                elif output_audio_codec == 'opus': filtered_audio_suffix = '.opus'
-                # Add more mappings if needed
-
-                temp_filtered_audio_file = tempfile.NamedTemporaryFile(suffix=filtered_audio_suffix, delete=False)
-                temp_filtered_audio_filepath = temp_filtered_audio_file.name
-                temp_filtered_audio_file.close()
-                temp_files_to_clean.append(temp_filtered_audio_filepath)
-                print(f"  Temp filtered audio file: {temp_filtered_audio_filepath}")
-                print(f"  Using audio codec: {output_audio_codec}, params: '{current_aParams}'")
-
-
-                # Construct filter command
-                ffmpeg_filter_audio_cmd = (
-                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
-                    f"-i \"{temp_raw_audio_filepath}\" "
-                    f"-filter_script \"{temp_filter_filepath}\" "
-                    f"-c:a {output_audio_codec} {current_aParams} " # Apply codec and remaining params
-                    f"{'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} "
-                    f"\"{temp_filtered_audio_filepath}\""
-                )
-                run_ffmpeg_command(ffmpeg_filter_audio_cmd, "Failed to filter audio stream")
-
-                # == Step 3: Mux Streams ==
-                print("Step 3: Muxing final video...")
-
-                # Base mux command inputs and maps
-                mux_inputs = f"-i \"{temp_video_filepath}\" -i \"{temp_filtered_audio_filepath}\""
-                mux_maps = "-map 0:v -map 1:a"
-                # Start with copy codecs, may be overridden
-                mux_codecs = "-c:v copy -c:a copy"
-
-                # Handle subtitle embedding (Input 2)
-                if self.embedSubs and os.path.isfile(self.cleanSubsFileSpec):
-                    mux_inputs += f" -i \"{self.cleanSubsFileSpec}\""
-                    mux_maps += " -map 2:s" # Map subtitles from input 2
-                    outFileParts = os.path.splitext(self.outputVidFileSpec)
-                    subs_codec = 'mov_text' if outFileParts[1] == '.mp4' else 'srt'
-                    # Add subtitle codec, disposition, metadata. Replace existing -c copy or add if needed
-                    mux_codecs += f" -c:s {subs_codec} -disposition:s:0 default -metadata:s:s:0 language={self.subsLang}"
-                else:
-                     mux_codecs += " -sn" # Explicitly remove subs if not embedding
-
-                # Handle hardcoding (overrides video copy in mux step)
-                if self.hardCode:
-                     if not os.path.isfile(self.cleanSubsFileSpec):
-                         print("Warning: Hardcode requested but clean subtitle file not found.")
-                     else:
-                         # Convert SRT to ASS if needed (reuse existing logic/variable)
-                         # Ensure assSubsFileSpec is defined within the class scope if needed elsewhere
-                         if not hasattr(self, 'assSubsFileSpec') or not self.assSubsFileSpec:
-                             self.assSubsFileSpec = os.path.splitext(self.cleanSubsFileSpec)[0] + '.ass'
-
-                         # Check if ASS file exists or needs conversion
-                         if not os.path.isfile(self.assSubsFileSpec) or os.path.getmtime(self.assSubsFileSpec) < os.path.getmtime(self.cleanSubsFileSpec):
-                             print("Converting SRT to ASS for hardcoding...")
-                             subConvCmd = f"ffmpeg -hide_banner -nostats -loglevel error -y -i \"{self.cleanSubsFileSpec}\" \"{self.assSubsFileSpec}\""
-                             run_ffmpeg_command(subConvCmd, "Failed to convert subtitles to ASS format")
-                             # Don't add ASS to temp_files_to_clean if we want to keep it
-                         else:
-                             print("Using existing ASS file for hardcoding.")
-
-
-                         if os.path.isfile(self.assSubsFileSpec):
-                             print("Applying hardcoded subtitles...")
-                             # Replace video codec copy with re-encode + filter
-                             video_encode_params = self.vParams # Use user/default encode params
-                             # Escape path for ffmpeg filter syntax (Windows needs special care)
-                             escaped_ass_path = self.assSubsFileSpec.replace('\\', '/').replace(':', '\\\\:')
-                             mux_codecs = re.sub(r'-c:v\s+copy', f"{video_encode_params} -vf \"ass='{escaped_ass_path}'\"", mux_codecs)
-                         else:
-                             print("Warning: Failed to find or create ASS file for hardcoding.")
-
-
-                ffmpeg_mux_cmd = (
-                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
-                    f"{mux_inputs} "
-                    f"{mux_maps} {mux_codecs} "
-                    f"{'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} "
-                    f"\"{self.outputVidFileSpec}\""
-                )
-                run_ffmpeg_command(ffmpeg_mux_cmd, "Failed to mux final video")
-
+                self.muteTimeList.insert(0, AUDIO_DOWNMIX_FILTER)
+            if (not self.subsOnly) and (len(self.muteTimeList) > 0):
+                audioFilter = f' -filter_complex "[0:a:{audioStreamOnlyIndex}]{",".join(self.muteTimeList)}[a{audioStreamOnlyIndex}]"'
             else:
-                # --- Original Logic (Simplified for no filtering) ---
-                print("Audio filtering not active. Using single-step ffmpeg process.")
-
-                # Determine video args (copy or re-encode/hardcode)
-                videoArgs = "-c:v copy" # Default
-                if self.reEncodeVideo or self.hardCode:
-                    if self.hardCode:
-                        if not os.path.isfile(self.cleanSubsFileSpec):
-                             print("Warning: Hardcode requested but clean subtitle file not found.")
-                             videoArgs = self.vParams # Fallback to re-encode without subs
-                        else:
-                             # Convert SRT to ASS if needed
-                             if not hasattr(self, 'assSubsFileSpec') or not self.assSubsFileSpec:
-                                 self.assSubsFileSpec = os.path.splitext(self.cleanSubsFileSpec)[0] + '.ass'
-                             if not os.path.isfile(self.assSubsFileSpec) or os.path.getmtime(self.assSubsFileSpec) < os.path.getmtime(self.cleanSubsFileSpec):
-                                 print("Converting SRT to ASS for hardcoding...")
-                                 subConvCmd = f"ffmpeg -hide_banner -nostats -loglevel error -y -i \"{self.cleanSubsFileSpec}\" \"{self.assSubsFileSpec}\""
-                                 run_ffmpeg_command(subConvCmd, "Failed to convert subtitles to ASS format")
-                             else:
-                                 print("Using existing ASS file for hardcoding.")
-
-                             if os.path.isfile(self.assSubsFileSpec):
-                                 escaped_ass_path = self.assSubsFileSpec.replace('\\', '/').replace(':', '\\\\:')
-                                 videoArgs = f"{self.vParams} -vf \"ass='{escaped_ass_path}'\""
-                             else:
-                                 print("Warning: Failed to find or create ASS file for hardcoding. Re-encoding video without subs.")
-                                 videoArgs = self.vParams
-                    else: # Just reEncodeVideo
-                        videoArgs = self.vParams
-                # else: videoArgs remains "-c:v copy"
-
-                # Determine audio args (use self.aParams, ensure stream specifier for target stream)
-                # Remove existing stream specifiers and add the correct one
-                audioArgs = re.sub(r'-(?:c|codec):a:\d+\s+', f'-c:a:{audioStreamOnlyIndex} ', self.aParams)
-                audioArgs = re.sub(r'-c:a\s+', f'-c:a:{audioStreamOnlyIndex} ', audioArgs) # Ensure specifier if only -c:a was present
-                # If no -c:a was present at all, add it with the specifier
-                if f'-c:a:{audioStreamOnlyIndex}' not in audioArgs and f'-codec:a:{audioStreamOnlyIndex}' not in audioArgs:
-                     # Extract codec from default if possible, fallback to copy
-                     default_codec_match = re.search(r'-c:a\s+(\S+)', AUDIO_DEFAULT_PARAMS)
-                     codec_to_use = default_codec_match.group(1) if default_codec_match else 'copy'
-                     audioArgs += f" -c:a:{audioStreamOnlyIndex} {codec_to_use}"
-
-
-                # Handle subtitle embedding
+                audioFilter = " "
+            if self.embedSubs and os.path.isfile(self.cleanSubsFileSpec):
+                outFileParts = os.path.splitext(self.outputVidFileSpec)
+                subsArgsInput = f" -i \"{self.cleanSubsFileSpec}\" "
+                subsArgsEmbed = f" -map 1:s -c:s {'mov_text' if outFileParts[1] == '.mp4' else 'srt'} -disposition:s:0 default -metadata:s:s:0 language={self.subsLang} "
+            else:
                 subsArgsInput = ""
-                subsArgsEmbed = "-sn" # Default to no subs
-                # Map target audio stream first
-                mapArgs = f"-map 0:v -map 0:a:{audioStreamOnlyIndex}"
-                # TODO: Add back mapping for other audio streams if needed (audioUnchangedMapList logic)
+                subsArgsEmbed = " -sn "
 
-                if self.embedSubs and os.path.isfile(self.cleanSubsFileSpec):
-                     subsArgsInput = f" -i \"{self.cleanSubsFileSpec}\""
-                     mapArgs += " -map 1:s" # Map subs from input 1
-                     outFileParts = os.path.splitext(self.outputVidFileSpec)
-                     subs_codec = 'mov_text' if outFileParts[1] == '.mp4' else 'srt'
-                     subsArgsEmbed = f"-c:s {subs_codec} -disposition:s:0 default -metadata:s:s:0 language={self.subsLang}"
-                # else: subsArgsEmbed remains "-sn"
+            ffmpegCmd = (
+                f"ffmpeg -hide_banner -nostats -loglevel error -y {'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} -i \""
+                + self.inputVidFileSpec
+                + "\""
+                + subsArgsInput
+                + audioFilter
+                + f' -map 0:v -map "[a{audioStreamOnlyIndex}]" {audioUnchangedMapList} '
+                + subsArgsEmbed
+                + videoArgs
+                + f" {self.aParams} {'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} \""
+                + self.outputVidFileSpec
+                + "\""
+            )
+            ffmpegResult = delegator.run(ffmpegCmd, block=True)
+            if (ffmpegResult.return_code != 0) or (not os.path.isfile(self.outputVidFileSpec)):
+                print(ffmpegCmd)
+                print(ffmpegResult.err)
+                raise ValueError(f'Could not process {self.inputVidFileSpec}')
+        else:
+            self.unalteredVideo = True
 
-
-                # Construct the single ffmpeg command
-                ffmpeg_cmd_single = (
-                     f"ffmpeg -hide_banner -nostats -loglevel error -y "
-                     f"{'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} "
-                     f"-i \"{self.inputVidFileSpec}\" {subsArgsInput} "
-                     f"{mapArgs} " # Map video, target audio, and potentially subs
-                     f"{videoArgs} {audioArgs} {subsArgsEmbed} " # Video codec, audio codec, subs codec/params or -sn
-                     f"{'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} "
-                     f"\"{self.outputVidFileSpec}\""
-                )
-                run_ffmpeg_command(ffmpeg_cmd_single, "Failed to process video (single step)")
-
-
-            # Final check if output file exists
-            if not os.path.isfile(self.outputVidFileSpec):
-                 raise ValueError(f'Output file {self.outputVidFileSpec} was not created successfully.')
-            else:
-                 print(f"Successfully created output file: {self.outputVidFileSpec}")
-
-        finally:
-            # Clean up the temporary filter script file
-            if temp_filter_filepath and os.path.exists(temp_filter_filepath):
-                try:
-                    os.remove(temp_filter_filepath)
-                    print(f"Cleaned up temporary filter script: {temp_filter_filepath}")
-                except OSError as e:
-                    print(f"Warning: Could not delete temporary filter file {temp_filter_filepath}: {e}")
-
-            # Clean up other temporary files
-            print(f"Cleaning up {len(temp_files_to_clean)} temporary file(s)...")
-            for temp_file in temp_files_to_clean:
-                if os.path.exists(temp_file):
-                    try:
-                        os.remove(temp_file)
-                        print(f"  Cleaned up: {temp_file}")
-                    except OSError as e:
-                        print(f"  Warning: Could not delete temporary file {temp_file}: {e}")
 
 #################################################################################
 def RunCleanvid():
@@ -891,156 +649,270 @@ def RunCleanvid():
     )
     parser.add_argument('--subs-output', help='output subtitle file', metavar='<output srt>', dest="subsOut")
     parser.add_argument(
+        '-w',
         '--swears',
-        help='pipe-delimited swears file (default: included swears.txt)',
+        help='text file containing profanity (with optional mapping)',
         default=os.path.join(__script_location__, 'swears.txt'),
-        metavar='<swears file>',
+        metavar='<profanity file>',
     )
     parser.add_argument(
-        '--swears-pad-sec',
-        help='seconds to pad swears (default: 0.0)',
-        type=float,
-        default=0.0,
-        metavar='<pad seconds>',
-        dest="swearsPadSec",
+        '-l',
+        '--lang',
+        help=f'language for extracting srt from video file or srt download (default is "{SUBTITLE_DEFAULT_LANG}")',
+        default=SUBTITLE_DEFAULT_LANG,
+        metavar='<language>',
     )
     parser.add_argument(
-        '--embed-subs', help='embed cleaned subtitle stream (default: false)', action='store_true', dest="embedSubs"
+        '-p', '--pad', help='pad (seconds) around profanity', metavar='<int>', dest="pad", type=float, default=0.0
     )
     parser.add_argument(
-        '--full-subs',
-        help='output full subtitle file with swears replaced (default: false, only outputs swear lines)',
+        '-e',
+        '--embed-subs',
+        help='embed subtitles in resulting video file',
+        dest='embedSubs',
         action='store_true',
-        dest="fullSubs",
+    )
+    parser.add_argument(
+        '-f',
+        '--full-subs',
+        help='include all subtitles in output subtitle file (not just scrubbed)',
+        dest='fullSubs',
+        action='store_true',
     )
     parser.add_argument(
         '--subs-only',
-        help='only generate subtitle file, do not process video (default: false)',
+        help='only operate on subtitles (do not alter audio)',
+        dest='subsOnly',
         action='store_true',
-        dest="subsOnly",
+    )
+    parser.add_argument(
+        '--offline',
+        help="don't attempt to download subtitles",
+        dest='offline',
+        action='store_true',
     )
     parser.add_argument(
         '--edl',
-        help='generate EDL file for video editors (also implies --subs-only) (default: false)',
+        help='generate MPlayer EDL file with mute actions (also implies --subs-only)',
+        dest='edl',
         action='store_true',
     )
     parser.add_argument(
         '--json',
-        help='generate JSON file detailing edits (default: false)',
+        help='generate JSON file with muted subtitles and their contents',
+        dest='json',
         action='store_true',
-        dest="jsonDump",
+    )
+    parser.add_argument('--re-encode-video', help='Re-encode video', dest='reEncodeVideo', action='store_true')
+    parser.add_argument('--re-encode-audio', help='Re-encode audio', dest='reEncodeAudio', action='store_true')
+    parser.add_argument(
+        '-b', '--burn', help='Hard-coded subtitles (implies re-encode)', dest='hardCode', action='store_true'
     )
     parser.add_argument(
-        '--subs-lang',
-        help='subtitle language (default: eng) (append :<index> to force specific stream index, e.g. eng:2)',
-        default=SUBTITLE_DEFAULT_LANG,
-        metavar='<language>',
-        dest="subsLang",
-    )
-    parser.add_argument(
-        '--re-encode-video',
-        help='force re-encode of video stream (default: false)',
-        action='store_true',
-        dest="reEncodeVideo",
-    )
-    parser.add_argument(
-        '--re-encode-audio',
-        help='force re-encode of audio stream (default: false)',
-        action='store_true',
-        dest="reEncodeAudio",
-    )
-    parser.add_argument(
-        '--hard-code',
-        help='hard-code (burn) cleaned subtitles into video stream (implies --re-encode-video) (default: false)',
-        action='store_true',
-        dest="hardCode",
-    )
-    parser.add_argument(
-        '--vparams',
-        help=f'video encoding parameters (default: {VIDEO_DEFAULT_PARAMS}) (prefix with base64: if needed)',
+        '-v',
+        '--video-params',
+        help='Video parameters for ffmpeg (only if re-encoding)',
+        dest='vParams',
         default=VIDEO_DEFAULT_PARAMS,
-        metavar='<ffmpeg video args>',
+    )
+    parser.add_argument(
+        '-a', '--audio-params', help='Audio parameters for ffmpeg', dest='aParams', default=AUDIO_DEFAULT_PARAMS
+    )
+    parser.add_argument(
+        '-d', '--downmix', help='Downmix to stereo (if not already stereo)', dest='aDownmix', action='store_true'
     )
     parser.add_argument(
         '--audio-stream-index',
-        help='audio stream index to process (default: auto-detect if only one stream)',
+        help='Index of audio stream to process',
+        metavar='<int>',
+        dest="audioStreamIdx",
         type=int,
         default=None,
-        metavar='<index>',
-        dest="audioStreamIdx",
     )
     parser.add_argument(
-        '--aparams',
-        help=f'audio encoding parameters (default: {AUDIO_DEFAULT_PARAMS}) (prefix with base64: if needed)',
-        default=AUDIO_DEFAULT_PARAMS,
-        metavar='<ffmpeg audio args>',
-    )
-    parser.add_argument(
-        '--audio-downmix',
-        help='downmix audio to stereo if input has more channels (default: false)',
+        '--audio-stream-list',
+        help='Show list of audio streams (to get index for --audio-stream-index)',
         action='store_true',
-        dest="aDownmix",
+        dest="audioStreamIdxList",
     )
     parser.add_argument(
         '--threads-input',
-        help='set threads for ffmpeg input processing (default: auto)',
+        help='ffmpeg global options -threads value',
+        metavar='<int>',
+        dest="threadsInput",
         type=int,
         default=None,
-        metavar='<threads>',
-        dest="threadsInput",
     )
     parser.add_argument(
         '--threads-encoding',
-        help='set threads for ffmpeg output encoding (default: auto)',
+        help='ffmpeg encoding options -threads value',
+        metavar='<int>',
+        dest="threadsEncoding",
         type=int,
         default=None,
-        metavar='<threads>',
-        dest="threadsEncoding",
     )
     parser.add_argument(
-        '--offline', help='do not attempt to download subtitles (default: false)', action='store_true'
+        '--threads',
+        help='ffmpeg -threads value (for both global options and encoding)',
+        metavar='<int>',
+        dest="threads",
+        type=int,
+        default=None,
     )
-
+    # --- Add --win flag ---
+    parser.add_argument(
+        '--win',
+        help='Use Windows-compatible multi-step processing (avoids command length errors)',
+        action='store_true',
+        dest="use_win_method" # Use a distinct destination variable
+    )
+    parser.set_defaults(
+        audioStreamIdxList=False,
+        edl=False,
+        embedSubs=False,
+        fullSubs=False,
+        hardCode=False,
+        offline=False,
+        reEncodeAudio=False,
+        reEncodeVideo=False,
+        subsOnly=False,
+        use_win_method=False, # Default to False
+    )
     args = parser.parse_args()
 
-    if args.hardCode:
-        args.reEncodeVideo = True
+    # --- Check for --win flag ---
+    if args.use_win_method:
+        # --- Execute cleanvidwin.py ---
+        print("Windows compatibility mode requested (--win). Delegating to cleanvidwin.py...")
 
-    if not args.output:
-        inParts = os.path.splitext(args.input)
-        args.output = inParts[0] + "_clean" + inParts[1]
+        # Construct path to cleanvidwin.py (assuming it's in the same directory)
+        script_dir = os.path.dirname(__file__)
+        cleanvidwin_path = os.path.join(script_dir, 'cleanvidwin.py')
 
-    if not args.subs:
-        args.subs = GetSubtitles(args.input, args.subsLang, args.offline)
+        if not os.path.exists(cleanvidwin_path):
+             print(f"Error: cleanvidwin.py not found at {cleanvidwin_path}", file=sys.stderr)
+             sys.exit(1)
 
-    cleaner = VidCleaner(
-        args.input,
-        args.subs,
-        args.output,
-        args.subsOut,
-        args.swears,
-        args.swearsPadSec,
-        args.embedSubs,
-        args.fullSubs,
-        args.subsOnly,
-        args.edl,
-        args.jsonDump,
-        args.subsLang,
-        args.reEncodeVideo,
-        args.reEncodeAudio,
-        args.hardCode,
-        args.vparams,
-        args.audioStreamIdx,
-        args.aparams,
-        args.aDownmix,
-        args.threadsInput,
-        args.threadsEncoding,
-        args.plexAutoSkipJson,
-        args.plexAutoSkipId,
-    )
-    cleaner.CreateCleanSubAndMuteList()
-    cleaner.MultiplexCleanVideo()
+        # Prepare arguments for cleanvidwin.py (pass all except the --win flag itself)
+        win_args = [arg for arg in sys.argv[1:] if arg != '--win']
+        print(f"Executing: {sys.executable} {cleanvidwin_path} {' '.join(win_args)}")
+
+        # Execute cleanvidwin.py using the same Python interpreter
+        try:
+            process_result = subprocess.run(
+                [sys.executable, cleanvidwin_path] + win_args,
+                check=True, # Raise exception on non-zero exit code
+                capture_output=False, # Let output go directly to console
+                text=True,
+                # Ensure environment variables like PATH are passed through if needed by ffmpeg
+                env=os.environ
+            )
+            print("cleanvidwin.py completed successfully.")
+            sys.exit(0) # Exit successfully after delegation
+        except subprocess.CalledProcessError as e:
+            print(f"Error executing cleanvidwin.py: {e}", file=sys.stderr)
+            # Optionally print stdout/stderr from the failed process if captured
+            # print(f"Stdout:\n{e.stdout}", file=sys.stderr)
+            # print(f"Stderr:\n{e.stderr}", file=sys.stderr)
+            sys.exit(e.returncode) # Exit with the same error code
+        except Exception as e:
+             print(f"An unexpected error occurred while trying to run cleanvidwin.py: {e}", file=sys.stderr)
+             sys.exit(1)
+
+    # --- Original Logic (if --win is not used) ---
+    else:
+        print("Using standard processing method. Use --win for Windows compatibility mode.")
+        if args.audioStreamIdxList:
+            audioStreamsInfo = GetAudioStreamsInfo(args.input)
+            # e.g.:
+            #   1: aac, 44100 Hz, stereo, eng
+            #   3: opus, 48000 Hz, stereo, jpn
+            print(
+                '\n'.join(
+                    [
+                        f"{x['index']}: {x.get('codec_name', 'unknown codec')}, {x.get('sample_rate', 'unknown')} Hz, {x.get('channel_layout', 'unknown channel layout')}, {x.get('tags', {}).get('language', 'unknown language')}"
+                        for x in audioStreamsInfo.get("streams", [])
+                    ]
+                )
+            )
+            sys.exit(0) # Exit after listing streams
+
+        # Proceed with normal processing setup
+        inFile = args.input
+        outFile = args.output
+        subsFile = args.subs
+        lang = args.lang
+        plexFile = args.plexAutoSkipJson
+        if inFile:
+            inFileParts = os.path.splitext(inFile)
+            if not outFile:
+                outFile = inFileParts[0] + "_clean" + inFileParts[1]
+            if not subsFile:
+                subsFile = GetSubtitles(inFile, lang, args.offline)
+            if args.plexAutoSkipId and not plexFile:
+                plexFile = inFileParts[0] + "_PlexAutoSkip_clean.json"
+
+        if plexFile and not args.plexAutoSkipId:
+            raise ValueError(
+                f'Content ID must be specified if creating a PlexAutoSkip JSON file (https://github.com/mdhiggins/PlexAutoSkip/wiki/Identifiers)'
+            )
+
+        # Instantiate the cleaner
+        try:
+            cleaner = VidCleaner(
+                inFile,
+                subsFile,
+                outFile,
+                args.subsOut,
+                args.swears,
+                args.pad,
+                args.embedSubs,
+                args.fullSubs,
+                args.subsOnly,
+                args.edl,
+                args.json,
+                lang,
+                args.reEncodeVideo,
+                args.reEncodeAudio,
+                args.hardCode,
+                args.vParams,
+                args.audioStreamIdx,
+                args.aParams,
+                args.aDownmix,
+                args.threadsInput if args.threadsInput is not None else args.threads,
+                args.threadsEncoding if args.threadsEncoding is not None else args.threads,
+                plexFile,
+                args.plexAutoSkipId,
+            )
+            cleaner.CreateCleanSubAndMuteList()
+            # --- Wrap the potentially failing call ---
+            cleaner.MultiplexCleanVideo()
+            print("Processing completed successfully using standard method.")
+
+        except ValueError as e:
+            print(f"\n--- Processing Error ---", file=sys.stderr)
+            print(f"Error details: {e}", file=sys.stderr)
+            # Check if it's likely the command length error (heuristic)
+            is_windows = sys.platform.startswith('win')
+            # Suggest --win only on Windows and if the error isn't about missing files/streams
+            # (More specific error checking could be added here if needed)
+            if is_windows:
+                 print("\nSuggestion: Processing failed.", file=sys.stderr)
+                 print("If you are on Windows and suspect a command-line length error,", file=sys.stderr)
+                 print("try running the command again with the --win flag added.", file=sys.stderr)
+            sys.exit(1) # Exit with error code after printing suggestion
+        except Exception as e:
+             # Catch other potential errors during original processing
+             print(f"\n--- Unexpected Error ---", file=sys.stderr)
+             print(f"Error details: {e}", file=sys.stderr)
+             # Consider printing traceback for unexpected errors
+             # import traceback
+             # traceback.print_exc(file=sys.stderr)
+             sys.exit(1)
 
 
-if __name__ == "__main__":
+#################################################################################
+if __name__ == '__main__':
     RunCleanvid()
+
+#################################################################################

--- a/src/cleanvid/cleanvidwin.py
+++ b/src/cleanvid/cleanvidwin.py
@@ -1,0 +1,1046 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import chardet
+import codecs
+import errno
+import json
+import os
+import shutil
+import sys
+import re
+import pysrt
+import delegator
+import tempfile # Added for temporary files
+from datetime import datetime
+from subliminal import *
+from babelfish import Language
+from collections import OrderedDict
+
+try:
+    from cleanvid.caselessdictionary import CaselessDictionary
+except ImportError:
+    from caselessdictionary import CaselessDictionary
+from itertools import tee
+
+__script_location__ = os.path.dirname(os.path.realpath(__file__))
+
+VIDEO_DEFAULT_PARAMS = '-c:v libx264 -preset slow -crf 22'
+AUDIO_DEFAULT_PARAMS = '-c:a aac -ab 224k -ar 44100'
+# for downmixing, https://superuser.com/questions/852400 was helpful
+AUDIO_DOWNMIX_FILTER = 'pan=stereo|FL=0.8*FC + 0.6*FL + 0.6*BL + 0.5*LFE|FR=0.8*FC + 0.6*FR + 0.6*BR + 0.5*LFE'
+SUBTITLE_DEFAULT_LANG = 'eng'
+PLEX_AUTO_SKIP_DEFAULT_CONFIG = '{"markers":{},"offsets":{},"tags":{},"allowed":{"users":[],"clients":[],"keys":[]},"blocked":{"users":[],"clients":[],"keys":[]},"clients":{},"mode":{}}'
+
+
+# thanks https://docs.python.org/3/library/itertools.html#recipes
+def pairwise(iterable):
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+######## GetFormatAndStreamInfo ###############################################
+def GetFormatAndStreamInfo(vidFileSpec):
+    result = None
+    if os.path.isfile(vidFileSpec):
+        ffprobeCmd = "ffprobe -loglevel quiet -print_format json -show_format -show_streams \"" + vidFileSpec + "\""
+        ffprobeResult = delegator.run(ffprobeCmd, block=True)
+        if ffprobeResult.return_code == 0:
+            result = json.loads(ffprobeResult.out)
+    return result
+
+
+######## GetAudioStreamsInfo ###############################################
+def GetAudioStreamsInfo(vidFileSpec):
+    result = None
+    if os.path.isfile(vidFileSpec):
+        ffprobeCmd = (
+            "ffprobe -loglevel quiet -select_streams a -show_entries stream=index,codec_name,sample_rate,channel_layout:stream_tags=language -of json \""
+            + vidFileSpec
+            + "\""
+        )
+        ffprobeResult = delegator.run(ffprobeCmd, block=True)
+        if ffprobeResult.return_code == 0:
+            result = json.loads(ffprobeResult.out)
+    return result
+
+
+######## GetStreamSubtitleMap ###############################################
+def GetStreamSubtitleMap(vidFileSpec):
+    result = None
+    if os.path.isfile(vidFileSpec):
+        ffprobeCmd = (
+            "ffprobe -loglevel quiet -select_streams s -show_entries stream=index:stream_tags=language -of csv=p=0 \""
+            + vidFileSpec
+            + "\""
+        )
+        ffprobeResult = delegator.run(ffprobeCmd, block=True)
+        if ffprobeResult.return_code == 0:
+            # e.g. for ara and chi, "-map 0:5 -map 0:7" or "-map 0:s:3 -map 0:s:5"
+            # 2,eng
+            # 3,eng
+            # 4,eng
+            # 5,ara
+            # 6,bul
+            # 7,chi
+            # 8,cze
+            # 9,dan
+            result = OrderedDict()
+            for l in [x.split(',') for x in ffprobeResult.out.split()]:
+                result[int(l[0])] = l[1]
+    return result
+
+
+######## HasAudioMoreThanStereo ###############################################
+def HasAudioMoreThanStereo(vidFileSpec):
+    result = False
+    if os.path.isfile(vidFileSpec):
+        ffprobeCmd = (
+            "ffprobe -loglevel quiet -select_streams a -show_entries stream=channels -of csv=p=0 \""
+            + vidFileSpec
+            + "\""
+        )
+        ffprobeResult = delegator.run(ffprobeCmd, block=True)
+        if ffprobeResult.return_code == 0:
+            result = any(
+                [
+                    x
+                    for x in [int(''.join([z for z in y if z.isdigit()])) for y in list(set(ffprobeResult.out.split()))]
+                    if x > 2
+                ]
+            )
+    return result
+
+
+######## SplitLanguageIfForced #####################################################
+def SplitLanguageIfForced(lang):
+    srtLanguageSplit = lang.split(':')
+    srtLanguage = srtLanguageSplit[0]
+    srtForceIndex = int(srtLanguageSplit[1]) if len(srtLanguageSplit) > 1 else None
+    return srtLanguage, srtForceIndex
+
+
+######## ExtractSubtitles #####################################################
+def ExtractSubtitles(vidFileSpec, srtLanguage):
+    subFileSpec = ""
+    srtLanguage, srtForceIndex = SplitLanguageIfForced(srtLanguage)
+    if (streamInfo := GetStreamSubtitleMap(vidFileSpec)) and (
+        stream := (
+            next(iter([k for k, v in streamInfo.items() if (v == srtLanguage)]), None)
+            if not srtForceIndex
+            else srtForceIndex
+        )
+    ):
+        subFileParts = os.path.splitext(vidFileSpec)
+        subFileSpec = subFileParts[0] + "." + srtLanguage + ".srt"
+        ffmpegCmd = (
+            "ffmpeg -hide_banner -nostats -loglevel error -y -i \""
+            + vidFileSpec
+            + f"\" -map 0:{stream} \""
+            + subFileSpec
+            + "\""
+        )
+        ffmpegResult = delegator.run(ffmpegCmd, block=True)
+        if (ffmpegResult.return_code != 0) or (not os.path.isfile(subFileSpec)):
+            subFileSpec = ""
+    return subFileSpec
+
+
+######## GetSubtitles #########################################################
+def GetSubtitles(vidFileSpec, srtLanguage, offline=False):
+    subFileSpec = ExtractSubtitles(vidFileSpec, srtLanguage)
+    if not os.path.isfile(subFileSpec):
+        if offline:
+            subFileSpec = ""
+        else:
+            if os.path.isfile(vidFileSpec):
+                subFileParts = os.path.splitext(vidFileSpec)
+                srtLanguage, srtForceIndex = SplitLanguageIfForced(srtLanguage)
+                subFileSpec = subFileParts[0] + "." + str(Language(srtLanguage)) + ".srt"
+                if not os.path.isfile(subFileSpec):
+                    video = Video.fromname(vidFileSpec)
+                    bestSubtitles = download_best_subtitles([video], {Language(srtLanguage)})
+                    savedSub = save_subtitles(video, [bestSubtitles[video][0]])
+
+            if subFileSpec and (not os.path.isfile(subFileSpec)):
+                subFileSpec = ""
+
+    return subFileSpec
+
+
+######## UTF8Convert #########################################################
+# attempt to convert any text file to UTF-* without BOM and normalize line endings
+def UTF8Convert(fileSpec, universalEndline=True):
+    # Read from file
+    with open(fileSpec, 'rb') as f:
+        raw = f.read()
+
+    # Decode
+    raw = raw.decode(chardet.detect(raw)['encoding'])
+
+    # Remove windows line endings
+    if universalEndline:
+        raw = raw.replace('\r\n', '\n')
+
+    # Encode to UTF-8
+    raw = raw.encode('utf8')
+
+    # Remove BOM
+    if raw.startswith(codecs.BOM_UTF8):
+        raw = raw.replace(codecs.BOM_UTF8, '', 1)
+
+    # Write to file
+    with open(fileSpec, 'wb') as f:
+        f.write(raw)
+
+# Helper function to run ffmpeg and check results
+def run_ffmpeg_command(command, error_message_prefix="ffmpeg command failed"):
+    print(f"Running ffmpeg command:\n{command}") # Log the command
+    result = delegator.run(command, block=True)
+    if result.return_code != 0:
+        print(f"ffmpeg stderr:\n{result.err}")
+        raise ValueError(f"{error_message_prefix}: {result.err}")
+    print("ffmpeg command completed successfully.")
+    return result
+
+#################################################################################
+class VidCleaner(object):
+    inputVidFileSpec = ""
+    inputSubsFileSpec = ""
+    cleanSubsFileSpec = ""
+    edlFileSpec = ""
+    jsonFileSpec = ""
+    tmpSubsFileSpec = ""
+    assSubsFileSpec = ""
+    outputVidFileSpec = ""
+    swearsFileSpec = ""
+    swearsPadMillisec = 0
+    embedSubs = False
+    fullSubs = False
+    subsOnly = False
+    edl = False
+    hardCode = False
+    reEncodeVideo = False
+    reEncodeAudio = False
+    unalteredVideo = False
+    subsLang = SUBTITLE_DEFAULT_LANG
+    vParams = VIDEO_DEFAULT_PARAMS
+    audioStreamIdx = None
+    aParams = AUDIO_DEFAULT_PARAMS
+    aDownmix = False
+    threadsInput = None
+    threadsEncoding = None
+    plexAutoSkipJson = ""
+    plexAutoSkipId = ""
+    swearsMap = CaselessDictionary({})
+    muteTimeList = []
+    jsonDumpList = None
+
+    ######## init #################################################################
+
+    def __init__(
+        self,
+        iVidFileSpec,
+        iSubsFileSpec,
+        oVidFileSpec,
+        oSubsFileSpec,
+        iSwearsFileSpec,
+        swearsPadSec=0.0,
+        embedSubs=False,
+        fullSubs=False,
+        subsOnly=False,
+        edl=False,
+        jsonDump=False,
+        subsLang=SUBTITLE_DEFAULT_LANG,
+        reEncodeVideo=False,
+        reEncodeAudio=False,
+        hardCode=False,
+        vParams=VIDEO_DEFAULT_PARAMS,
+        audioStreamIdx=None,
+        aParams=AUDIO_DEFAULT_PARAMS,
+        aDownmix=False,
+        threadsInput=None,
+        threadsEncoding=None,
+        plexAutoSkipJson="",
+        plexAutoSkipId="",
+    ):
+        if (iVidFileSpec is not None) and os.path.isfile(iVidFileSpec):
+            self.inputVidFileSpec = iVidFileSpec
+        else:
+            raise IOError(errno.ENOENT, os.strerror(errno.ENOENT), iVidFileSpec)
+
+        if (iSubsFileSpec is not None) and os.path.isfile(iSubsFileSpec):
+            self.inputSubsFileSpec = iSubsFileSpec
+
+        if (iSwearsFileSpec is not None) and os.path.isfile(iSwearsFileSpec):
+            self.swearsFileSpec = iSwearsFileSpec
+        else:
+            raise IOError(errno.ENOENT, os.strerror(errno.ENOENT), iSwearsFileSpec)
+
+        if (oVidFileSpec is not None) and (len(oVidFileSpec) > 0):
+            self.outputVidFileSpec = oVidFileSpec
+            if os.path.isfile(self.outputVidFileSpec):
+                os.remove(self.outputVidFileSpec)
+
+        if (oSubsFileSpec is not None) and (len(oSubsFileSpec) > 0):
+            self.cleanSubsFileSpec = oSubsFileSpec
+            if os.path.isfile(self.cleanSubsFileSpec):
+                os.remove(self.cleanSubsFileSpec)
+
+        self.swearsPadMillisec = round(swearsPadSec * 1000.0)
+        self.embedSubs = embedSubs
+        self.fullSubs = fullSubs
+        self.subsOnly = subsOnly or edl or (plexAutoSkipJson and plexAutoSkipId)
+        self.edl = edl
+        self.jsonDumpList = [] if jsonDump else None
+        self.plexAutoSkipJson = plexAutoSkipJson
+        self.plexAutoSkipId = plexAutoSkipId
+        self.reEncodeVideo = reEncodeVideo
+        self.reEncodeAudio = reEncodeAudio
+        self.hardCode = hardCode
+        self.subsLang = subsLang
+        self.vParams = vParams
+        self.audioStreamIdx = audioStreamIdx
+        self.aParams = aParams
+        self.aDownmix = aDownmix
+        self.threadsInput = threadsInput
+        self.threadsEncoding = threadsEncoding
+        if self.vParams.startswith('base64:'):
+            self.vParams = base64.b64decode(self.vParams[7:]).decode('utf-8')
+        if self.aParams.startswith('base64:'):
+            self.aParams = base64.b64decode(self.aParams[7:]).decode('utf-8')
+
+    ######## del ##################################################################
+    def __del__(self):
+        if (not os.path.isfile(self.outputVidFileSpec)) and (not self.unalteredVideo):
+            if os.path.isfile(self.cleanSubsFileSpec):
+                os.remove(self.cleanSubsFileSpec)
+            if os.path.isfile(self.edlFileSpec):
+                os.remove(self.edlFileSpec)
+            if os.path.isfile(self.jsonFileSpec):
+                os.remove(self.jsonFileSpec)
+        if os.path.isfile(self.tmpSubsFileSpec):
+            os.remove(self.tmpSubsFileSpec)
+        if os.path.isfile(self.assSubsFileSpec) and not self.hardCode: # Keep ASS if hardcoding succeeded
+             try:
+                 os.remove(self.assSubsFileSpec)
+             except OSError:
+                 pass # Ignore error if file is gone
+
+    ######## CreateCleanSubAndMuteList #################################################
+    def CreateCleanSubAndMuteList(self):
+        if (self.inputSubsFileSpec is None) or (not os.path.isfile(self.inputSubsFileSpec)):
+            raise IOError(
+                errno.ENOENT,
+                f"Input subtitle file unspecified or not found ({os.strerror(errno.ENOENT)})",
+                self.inputSubsFileSpec,
+            )
+
+        subFileParts = os.path.splitext(self.inputSubsFileSpec)
+
+        self.tmpSubsFileSpec = subFileParts[0] + "_utf8" + subFileParts[1]
+        shutil.copy2(self.inputSubsFileSpec, self.tmpSubsFileSpec)
+        UTF8Convert(self.tmpSubsFileSpec)
+
+        if not self.cleanSubsFileSpec:
+            self.cleanSubsFileSpec = subFileParts[0] + "_clean" + subFileParts[1]
+
+        if not self.edlFileSpec:
+            cleanSubFileParts = os.path.splitext(self.cleanSubsFileSpec)
+            self.edlFileSpec = cleanSubFileParts[0] + '.edl'
+
+        if (self.jsonDumpList is not None) and (not self.jsonFileSpec):
+            cleanSubFileParts = os.path.splitext(self.cleanSubsFileSpec)
+            self.jsonFileSpec = cleanSubFileParts[0] + '.json'
+
+        lines = []
+
+        with open(self.swearsFileSpec) as f:
+            lines = [line.rstrip('\n') for line in f]
+
+        for line in lines:
+            lineMap = line.split("|")
+            if len(lineMap) > 1:
+                self.swearsMap[lineMap[0]] = lineMap[1]
+            else:
+                self.swearsMap[lineMap[0]] = "*****"
+
+        replacer = re.compile(r'\b(' + '|'.join(self.swearsMap.keys()) + r')\b', re.IGNORECASE)
+
+        subs = pysrt.open(self.tmpSubsFileSpec)
+        newSubs = pysrt.SubRipFile()
+        newTimestampPairs = []
+
+        # append a dummy sub at the very end so that pairwise can peek and see nothing
+        subs.append(
+            pysrt.SubRipItem(
+                index=len(subs) + 1,
+                start=(subs[-1].end.seconds if subs else 0) + 1,
+                end=(subs[-1].end.seconds if subs else 0) + 2,
+                text='Fin',
+            )
+        )
+
+        # for each subtitle in the set
+        # if text contains profanity...
+        # OR if the next text contains profanity and lies within the pad ...
+        # OR if the previous text contained profanity and lies within the pad ...
+        # then include the subtitle in the new set
+        prevNaughtySub = None
+        for sub, subPeek in pairwise(subs):
+            newText = replacer.sub(lambda x: self.swearsMap[x.group()], sub.text)
+            newTextPeek = (
+                replacer.sub(lambda x: self.swearsMap[x.group()], subPeek.text) if (subPeek is not None) else None
+            )
+            # this sub contains profanity, or
+            if (
+                (newText != sub.text)
+                or
+                # we have defined a pad, and
+                (
+                    (self.swearsPadMillisec > 0)
+                    and (newTextPeek is not None)
+                    and
+                    # the next sub contains profanity and is within pad seconds of this one, or
+                    (
+                        (
+                            (newTextPeek != subPeek.text)
+                            and ((subPeek.start.ordinal - sub.end.ordinal) <= self.swearsPadMillisec)
+                        )
+                        or
+                        # the previous sub contained profanity and is within pad seconds of this one
+                        (
+                            (prevNaughtySub is not None)
+                            and ((sub.start.ordinal - prevNaughtySub.end.ordinal) <= self.swearsPadMillisec)
+                        )
+                    )
+                )
+            ):
+                subScrubbed = newText != sub.text
+                if subScrubbed and (self.jsonDumpList is not None):
+                    self.jsonDumpList.append(
+                        {
+                            'old': sub.text,
+                            'new': newText,
+                            'start': str(sub.start),
+                            'end': str(sub.end),
+                        }
+                    )
+                newSub = sub
+                newSub.text = newText
+                newSubs.append(newSub)
+                if subScrubbed:
+                    prevNaughtySub = sub
+                    newTimes = [
+                        pysrt.SubRipTime.from_ordinal(sub.start.ordinal - self.swearsPadMillisec).to_time(),
+                        pysrt.SubRipTime.from_ordinal(sub.end.ordinal + self.swearsPadMillisec).to_time(),
+                    ]
+                else:
+                    prevNaughtySub = None
+                    newTimes = [sub.start.to_time(), sub.end.to_time()]
+                newTimestampPairs.append(newTimes)
+            else:
+                if self.fullSubs:
+                    newSubs.append(sub)
+                prevNaughtySub = None
+
+        newSubs.save(self.cleanSubsFileSpec)
+        if self.jsonDumpList is not None:
+            with open(self.jsonFileSpec, "w") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "now": datetime.now().isoformat(),
+                            "edits": self.jsonDumpList,
+                            "media": {
+                                "input": self.inputVidFileSpec,
+                                "output": self.outputVidFileSpec,
+                                "ffprobe": GetFormatAndStreamInfo(self.inputVidFileSpec),
+                            },
+                            "subtitles": {
+                                "input": self.inputSubsFileSpec,
+                                "output": self.cleanSubsFileSpec,
+                            },
+                        },
+                        indent=4,
+                    )
+                )
+
+        self.muteTimeList = []
+        edlLines = []
+        plexDict = json.loads(PLEX_AUTO_SKIP_DEFAULT_CONFIG) if self.plexAutoSkipId and self.plexAutoSkipJson else None
+
+        if plexDict:
+            plexDict["markers"][self.plexAutoSkipId] = []
+            plexDict["mode"][self.plexAutoSkipId] = "volume"
+
+        # Append one at the very end of the file to work with pairwise
+        newTimes = [pysrt.SubRipTime.from_ordinal(subs[-1].end.ordinal).to_time(), None]
+        newTimestampPairs.append(newTimes)
+
+        for timePair, timePairPeek in pairwise(newTimestampPairs):
+            lineStart = (
+                (timePair[0].hour * 60.0 * 60.0)
+                + (timePair[0].minute * 60.0)
+                + timePair[0].second
+                + (timePair[0].microsecond / 1000000.0)
+            )
+            lineEnd = (
+                (timePair[1].hour * 60.0 * 60.0)
+                + (timePair[1].minute * 60.0)
+                + timePair[1].second
+                + (timePair[1].microsecond / 1000000.0)
+            )
+            lineStartPeek = (
+                (timePairPeek[0].hour * 60.0 * 60.0)
+                + (timePairPeek[0].minute * 60.0)
+                + timePairPeek[0].second
+                + (timePairPeek[0].microsecond / 1000000.0)
+            )
+            # Build filter graph components for audio filtering
+            # Using afade for smoother transitions (original logic)
+            self.muteTimeList.append(
+                "afade=enable='between(t,"
+                + format(lineStart, '.3f')
+                + ","
+                + format(lineEnd, '.3f')
+                + ")':t=out:st="
+                + format(lineStart, '.3f')
+                + ":d=10ms" # Mute section (fade out)
+            )
+            self.muteTimeList.append(
+                "afade=enable='between(t,"
+                + format(lineEnd, '.3f')
+                + ","
+                + format(lineStartPeek, '.3f') # Use peek for fade-in start
+                + ")':t=in:st="
+                + format(lineEnd, '.3f')
+                + ":d=10ms" # Unmute section (fade in)
+            )
+
+            if self.edl:
+                edlLines.append(f"{format(lineStart, '.1f')}\t{format(lineEnd, '.3f')}\t1")
+            if plexDict:
+                plexDict["markers"][self.plexAutoSkipId].append(
+                    {"start": round(lineStart * 1000.0), "end": round(lineEnd * 1000.0), "mode": "volume"}
+                )
+        if self.edl and (len(edlLines) > 0):
+            with open(self.edlFileSpec, 'w') as edlFile:
+                for item in edlLines:
+                    edlFile.write(f"{item}\n")
+        if plexDict and (len(plexDict["markers"][self.plexAutoSkipId]) > 0):
+            json.dump(
+                plexDict,
+                open(self.plexAutoSkipJson, 'w'),
+                indent=4,
+            )
+
+    ######## MultiplexCleanVideo ###################################################
+    def MultiplexCleanVideo(self):
+        temp_files_to_clean = [] # List to hold paths of temp files for cleanup
+        temp_filter_filepath = None # Keep this separate as it's handled slightly differently
+        audioStreams = None # Define audioStreams in the broader scope
+
+        try:
+            # Determine if video processing is needed (existing logic)
+            needs_processing = (
+                self.reEncodeVideo
+                or self.reEncodeAudio
+                or self.hardCode
+                or self.embedSubs
+                or ((not self.subsOnly) and (len(self.muteTimeList) > 0)) # Check original muteTimeList length
+            )
+
+            if not needs_processing:
+                self.unalteredVideo = True
+                print("No video/audio processing required based on options.")
+                return # Exit early if no processing needed
+
+            # --- Determine audio stream index ---
+            audioStreamOnlyIndex = 0 # Default to first stream if index not specified/found
+            audioStreams = GetAudioStreamsInfo(self.inputVidFileSpec)
+            if not audioStreams or 'streams' not in audioStreams or not audioStreams['streams']:
+                 raise ValueError(f'Could not determine audio streams in {self.inputVidFileSpec}')
+
+            actual_streams = audioStreams['streams']
+            if self.audioStreamIdx is None:
+                if len(actual_streams) == 1:
+                    if 'index' in actual_streams[0]:
+                        self.audioStreamIdx = actual_streams[0]['index']
+                        # Find the 0-based index for mapping
+                        audioStreamOnlyIndex = next((i for i, s in enumerate(actual_streams) if s.get('index') == self.audioStreamIdx), 0)
+                    else:
+                        raise ValueError(f'Could not determine audio stream index for {self.inputVidFileSpec}')
+                else:
+                    raise ValueError(
+                        f'Multiple audio streams ({len(actual_streams)} found), specify audio stream index with --audio-stream-index'
+                    )
+            elif any(stream.get('index', -1) == self.audioStreamIdx for stream in actual_streams):
+                 # Find the 0-based index for mapping
+                 audioStreamOnlyIndex = next((i for i, s in enumerate(actual_streams) if s.get('index') == self.audioStreamIdx), 0)
+            else:
+                raise ValueError(
+                    f'Audio stream index {self.audioStreamIdx} is invalid for {self.inputVidFileSpec}'
+                )
+
+            # Apply stream index to aParams if needed (original logic modified)
+            # This might add complexity if aParams already has stream specifiers.
+            # Let's simplify: we'll handle codec selection explicitly later.
+            # self.aParams = re.sub(r"-c:a(\s+)", rf"-c:a:{str(audioStreamOnlyIndex)}\1", self.aParams)
+            print(f"Selected audio stream: Input Index={self.audioStreamIdx}, FFmpeg Map Index=0:a:{audioStreamOnlyIndex}")
+
+
+            # --- Determine if audio filtering is needed ---
+            # Note: muteTimeList is populated in CreateCleanSubAndMuteList
+            if self.aDownmix and HasAudioMoreThanStereo(self.inputVidFileSpec):
+                # Prepend downmix filter if needed *before* checking length
+                if AUDIO_DOWNMIX_FILTER not in self.muteTimeList: # Avoid duplicates
+                    self.muteTimeList.insert(0, AUDIO_DOWNMIX_FILTER)
+
+            audio_filtering_active = (not self.subsOnly) and (len(self.muteTimeList) > 0)
+
+            # --- Main Processing Logic ---
+            if audio_filtering_active:
+                print("Audio filtering is active. Using multi-step ffmpeg process.")
+
+                # == Step 1: Split Streams ==
+                print("Step 1: Splitting video and audio streams...")
+
+                # Create temporary files (manage deletion manually in finally)
+                # Use mkv as intermediate container for video, wav for raw audio
+                temp_video_file = tempfile.NamedTemporaryFile(suffix=".mkv", delete=False)
+                temp_raw_audio_file = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+                temp_video_filepath = temp_video_file.name
+                temp_raw_audio_filepath = temp_raw_audio_file.name
+                temp_video_file.close() # Close handles immediately
+                temp_raw_audio_file.close()
+                temp_files_to_clean.extend([temp_video_filepath, temp_raw_audio_filepath])
+                print(f"  Temp video file: {temp_video_filepath}")
+                print(f"  Temp raw audio file: {temp_raw_audio_filepath}")
+
+                # 1a: Extract video (copy)
+                ffmpeg_split_video_cmd = (
+                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
+                    f"{'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} "
+                    f"-i \"{self.inputVidFileSpec}\" "
+                    f"-map 0:v -c:v copy -dn -sn " # Copy video, drop data/subs
+                    f"\"{temp_video_filepath}\""
+                )
+                run_ffmpeg_command(ffmpeg_split_video_cmd, "Failed to split video stream")
+
+                # 1b: Extract and decode audio to WAV
+                ffmpeg_split_audio_cmd = (
+                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
+                    f"{'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} "
+                    f"-i \"{self.inputVidFileSpec}\" "
+                    f"-map 0:a:{audioStreamOnlyIndex} -c:a pcm_s16le " # Decode to WAV
+                    f"\"{temp_raw_audio_filepath}\""
+                )
+                run_ffmpeg_command(ffmpeg_split_audio_cmd, "Failed to split and decode audio stream")
+
+                # == Step 2: Filter Audio ==
+                print("Step 2: Filtering audio stream...")
+
+                # Create filter script file
+                filter_graph_content = ",".join(self.muteTimeList)
+                temp_filter_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt', encoding='utf-8')
+                temp_filter_filepath = temp_filter_file.name # Store path for cleanup
+                # Filtergraph for single WAV input doesn't need stream specifiers like [0:a:0]
+                # It implicitly operates on the input stream.
+                temp_filter_file.write(f"{filter_graph_content}")
+                temp_filter_file.close()
+                temp_files_to_clean.append(temp_filter_filepath) # Add filter script for cleanup
+                print(f"  Temp filter script: {temp_filter_filepath}")
+
+
+                # Determine output audio parameters (remove stream specifiers if present)
+                # Use default codec if 'copy' is specified, otherwise use provided params
+                current_aParams = self.aParams
+                default_codec_match = re.search(r'-c:a\s+(\S+)', AUDIO_DEFAULT_PARAMS)
+                default_codec = default_codec_match.group(1) if default_codec_match else 'aac'
+                output_audio_codec = default_codec # Default to AAC
+
+                # Try to extract codec and other params from self.aParams
+                # Remove any stream specifiers first
+                current_aParams = re.sub(r'-c:a:\d+\s+', '-c:a ', current_aParams)
+                current_aParams = re.sub(r'-codec:a:\d+\s+', '-codec:a ', current_aParams)
+
+                codec_match = re.search(r'-(?:c|codec):a\s+(\S+)', current_aParams)
+                if codec_match:
+                    specified_codec = codec_match.group(1)
+                    if specified_codec.lower() != 'copy':
+                        output_audio_codec = specified_codec
+                        # Remove the codec part to keep other params like bitrate, etc.
+                        current_aParams = re.sub(r'\s*-(?:c|codec):a\s+\S+', '', current_aParams).strip()
+                    else:
+                        # If 'copy' was specified, just use default codec and ignore other params in self.aParams for this step
+                         current_aParams = re.sub(r'\s*-(?:c|codec):a\s+copy', '', current_aParams).strip()
+                else:
+                    # No codec specified in aParams, use default
+                    output_audio_codec = default_codec
+                    current_aParams = "" # Clear params if only default codec is used
+
+                # Determine filtered audio file extension based on codec
+                filtered_audio_suffix = f".{output_audio_codec}"
+                if output_audio_codec == 'aac': filtered_audio_suffix = '.m4a'
+                elif output_audio_codec == 'ac3': filtered_audio_suffix = '.ac3'
+                elif output_audio_codec == 'opus': filtered_audio_suffix = '.opus'
+                # Add more mappings if needed
+
+                temp_filtered_audio_file = tempfile.NamedTemporaryFile(suffix=filtered_audio_suffix, delete=False)
+                temp_filtered_audio_filepath = temp_filtered_audio_file.name
+                temp_filtered_audio_file.close()
+                temp_files_to_clean.append(temp_filtered_audio_filepath)
+                print(f"  Temp filtered audio file: {temp_filtered_audio_filepath}")
+                print(f"  Using audio codec: {output_audio_codec}, params: '{current_aParams}'")
+
+
+                # Construct filter command
+                ffmpeg_filter_audio_cmd = (
+                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
+                    f"-i \"{temp_raw_audio_filepath}\" "
+                    f"-filter_script \"{temp_filter_filepath}\" "
+                    f"-c:a {output_audio_codec} {current_aParams} " # Apply codec and remaining params
+                    f"{'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} "
+                    f"\"{temp_filtered_audio_filepath}\""
+                )
+                run_ffmpeg_command(ffmpeg_filter_audio_cmd, "Failed to filter audio stream")
+
+                # == Step 3: Mux Streams ==
+                print("Step 3: Muxing final video...")
+
+                # Base mux command inputs and maps
+                mux_inputs = f"-i \"{temp_video_filepath}\" -i \"{temp_filtered_audio_filepath}\""
+                mux_maps = "-map 0:v -map 1:a"
+                # Start with copy codecs, may be overridden
+                mux_codecs = "-c:v copy -c:a copy"
+
+                # Handle subtitle embedding (Input 2)
+                if self.embedSubs and os.path.isfile(self.cleanSubsFileSpec):
+                    mux_inputs += f" -i \"{self.cleanSubsFileSpec}\""
+                    mux_maps += " -map 2:s" # Map subtitles from input 2
+                    outFileParts = os.path.splitext(self.outputVidFileSpec)
+                    subs_codec = 'mov_text' if outFileParts[1] == '.mp4' else 'srt'
+                    # Add subtitle codec, disposition, metadata. Replace existing -c copy or add if needed
+                    mux_codecs += f" -c:s {subs_codec} -disposition:s:0 default -metadata:s:s:0 language={self.subsLang}"
+                else:
+                     mux_codecs += " -sn" # Explicitly remove subs if not embedding
+
+                # Handle hardcoding (overrides video copy in mux step)
+                if self.hardCode:
+                     if not os.path.isfile(self.cleanSubsFileSpec):
+                         print("Warning: Hardcode requested but clean subtitle file not found.")
+                     else:
+                         # Convert SRT to ASS if needed (reuse existing logic/variable)
+                         # Ensure assSubsFileSpec is defined within the class scope if needed elsewhere
+                         if not hasattr(self, 'assSubsFileSpec') or not self.assSubsFileSpec:
+                             self.assSubsFileSpec = os.path.splitext(self.cleanSubsFileSpec)[0] + '.ass'
+
+                         # Check if ASS file exists or needs conversion
+                         if not os.path.isfile(self.assSubsFileSpec) or os.path.getmtime(self.assSubsFileSpec) < os.path.getmtime(self.cleanSubsFileSpec):
+                             print("Converting SRT to ASS for hardcoding...")
+                             subConvCmd = f"ffmpeg -hide_banner -nostats -loglevel error -y -i \"{self.cleanSubsFileSpec}\" \"{self.assSubsFileSpec}\""
+                             run_ffmpeg_command(subConvCmd, "Failed to convert subtitles to ASS format")
+                             # Don't add ASS to temp_files_to_clean if we want to keep it
+                         else:
+                             print("Using existing ASS file for hardcoding.")
+
+
+                         if os.path.isfile(self.assSubsFileSpec):
+                             print("Applying hardcoded subtitles...")
+                             # Replace video codec copy with re-encode + filter
+                             video_encode_params = self.vParams # Use user/default encode params
+                             # Escape path for ffmpeg filter syntax (Windows needs special care)
+                             escaped_ass_path = self.assSubsFileSpec.replace('\\', '/').replace(':', '\\\\:')
+                             mux_codecs = re.sub(r'-c:v\s+copy', f"{video_encode_params} -vf \"ass='{escaped_ass_path}'\"", mux_codecs)
+                         else:
+                             print("Warning: Failed to find or create ASS file for hardcoding.")
+
+
+                ffmpeg_mux_cmd = (
+                    f"ffmpeg -hide_banner -nostats -loglevel error -y "
+                    f"{mux_inputs} "
+                    f"{mux_maps} {mux_codecs} "
+                    f"{'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} "
+                    f"\"{self.outputVidFileSpec}\""
+                )
+                run_ffmpeg_command(ffmpeg_mux_cmd, "Failed to mux final video")
+
+            else:
+                # --- Original Logic (Simplified for no filtering) ---
+                print("Audio filtering not active. Using single-step ffmpeg process.")
+
+                # Determine video args (copy or re-encode/hardcode)
+                videoArgs = "-c:v copy" # Default
+                if self.reEncodeVideo or self.hardCode:
+                    if self.hardCode:
+                        if not os.path.isfile(self.cleanSubsFileSpec):
+                             print("Warning: Hardcode requested but clean subtitle file not found.")
+                             videoArgs = self.vParams # Fallback to re-encode without subs
+                        else:
+                             # Convert SRT to ASS if needed
+                             if not hasattr(self, 'assSubsFileSpec') or not self.assSubsFileSpec:
+                                 self.assSubsFileSpec = os.path.splitext(self.cleanSubsFileSpec)[0] + '.ass'
+                             if not os.path.isfile(self.assSubsFileSpec) or os.path.getmtime(self.assSubsFileSpec) < os.path.getmtime(self.cleanSubsFileSpec):
+                                 print("Converting SRT to ASS for hardcoding...")
+                                 subConvCmd = f"ffmpeg -hide_banner -nostats -loglevel error -y -i \"{self.cleanSubsFileSpec}\" \"{self.assSubsFileSpec}\""
+                                 run_ffmpeg_command(subConvCmd, "Failed to convert subtitles to ASS format")
+                             else:
+                                 print("Using existing ASS file for hardcoding.")
+
+                             if os.path.isfile(self.assSubsFileSpec):
+                                 escaped_ass_path = self.assSubsFileSpec.replace('\\', '/').replace(':', '\\\\:')
+                                 videoArgs = f"{self.vParams} -vf \"ass='{escaped_ass_path}'\""
+                             else:
+                                 print("Warning: Failed to find or create ASS file for hardcoding. Re-encoding video without subs.")
+                                 videoArgs = self.vParams
+                    else: # Just reEncodeVideo
+                        videoArgs = self.vParams
+                # else: videoArgs remains "-c:v copy"
+
+                # Determine audio args (use self.aParams, ensure stream specifier for target stream)
+                # Remove existing stream specifiers and add the correct one
+                audioArgs = re.sub(r'-(?:c|codec):a:\d+\s+', f'-c:a:{audioStreamOnlyIndex} ', self.aParams)
+                audioArgs = re.sub(r'-c:a\s+', f'-c:a:{audioStreamOnlyIndex} ', audioArgs) # Ensure specifier if only -c:a was present
+                # If no -c:a was present at all, add it with the specifier
+                if f'-c:a:{audioStreamOnlyIndex}' not in audioArgs and f'-codec:a:{audioStreamOnlyIndex}' not in audioArgs:
+                     # Extract codec from default if possible, fallback to copy
+                     default_codec_match = re.search(r'-c:a\s+(\S+)', AUDIO_DEFAULT_PARAMS)
+                     codec_to_use = default_codec_match.group(1) if default_codec_match else 'copy'
+                     audioArgs += f" -c:a:{audioStreamOnlyIndex} {codec_to_use}"
+
+
+                # Handle subtitle embedding
+                subsArgsInput = ""
+                subsArgsEmbed = "-sn" # Default to no subs
+                # Map target audio stream first
+                mapArgs = f"-map 0:v -map 0:a:{audioStreamOnlyIndex}"
+                # TODO: Add back mapping for other audio streams if needed (audioUnchangedMapList logic)
+
+                if self.embedSubs and os.path.isfile(self.cleanSubsFileSpec):
+                     subsArgsInput = f" -i \"{self.cleanSubsFileSpec}\""
+                     mapArgs += " -map 1:s" # Map subs from input 1
+                     outFileParts = os.path.splitext(self.outputVidFileSpec)
+                     subs_codec = 'mov_text' if outFileParts[1] == '.mp4' else 'srt'
+                     subsArgsEmbed = f"-c:s {subs_codec} -disposition:s:0 default -metadata:s:s:0 language={self.subsLang}"
+                # else: subsArgsEmbed remains "-sn"
+
+
+                # Construct the single ffmpeg command
+                ffmpeg_cmd_single = (
+                     f"ffmpeg -hide_banner -nostats -loglevel error -y "
+                     f"{'' if self.threadsInput is None else ('-threads '+ str(int(self.threadsInput)))} "
+                     f"-i \"{self.inputVidFileSpec}\" {subsArgsInput} "
+                     f"{mapArgs} " # Map video, target audio, and potentially subs
+                     f"{videoArgs} {audioArgs} {subsArgsEmbed} " # Video codec, audio codec, subs codec/params or -sn
+                     f"{'' if self.threadsEncoding is None else ('-threads '+ str(int(self.threadsEncoding)))} "
+                     f"\"{self.outputVidFileSpec}\""
+                )
+                run_ffmpeg_command(ffmpeg_cmd_single, "Failed to process video (single step)")
+
+
+            # Final check if output file exists
+            if not os.path.isfile(self.outputVidFileSpec):
+                 raise ValueError(f'Output file {self.outputVidFileSpec} was not created successfully.')
+            else:
+                 print(f"Successfully created output file: {self.outputVidFileSpec}")
+
+        finally:
+            # Clean up the temporary filter script file
+            if temp_filter_filepath and os.path.exists(temp_filter_filepath):
+                try:
+                    os.remove(temp_filter_filepath)
+                    print(f"Cleaned up temporary filter script: {temp_filter_filepath}")
+                except OSError as e:
+                    print(f"Warning: Could not delete temporary filter file {temp_filter_filepath}: {e}")
+
+            # Clean up other temporary files
+            print(f"Cleaning up {len(temp_files_to_clean)} temporary file(s)...")
+            for temp_file in temp_files_to_clean:
+                if os.path.exists(temp_file):
+                    try:
+                        os.remove(temp_file)
+                        print(f"  Cleaned up: {temp_file}")
+                    except OSError as e:
+                        print(f"  Warning: Could not delete temporary file {temp_file}: {e}")
+
+#################################################################################
+def RunCleanvid():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-s',
+        '--subs',
+        help='.srt subtitle file (will attempt auto-download if unspecified and not --offline)',
+        metavar='<srt>',
+    )
+    parser.add_argument('-i', '--input', required=True, help='input video file', metavar='<input video>')
+    parser.add_argument('-o', '--output', help='output video file', metavar='<output video>')
+    parser.add_argument(
+        '--plex-auto-skip-json',
+        help='custom JSON file for PlexAutoSkip (also implies --subs-only)',
+        metavar='<output JSON>',
+        dest="plexAutoSkipJson",
+    )
+    parser.add_argument(
+        '--plex-auto-skip-id',
+        help='content identifier for PlexAutoSkip (also implies --subs-only)',
+        metavar='<content identifier>',
+        dest="plexAutoSkipId",
+    )
+    parser.add_argument('--subs-output', help='output subtitle file', metavar='<output srt>', dest="subsOut")
+    parser.add_argument(
+        '--swears',
+        help='pipe-delimited swears file (default: included swears.txt)',
+        default=os.path.join(__script_location__, 'swears.txt'),
+        metavar='<swears file>',
+    )
+    parser.add_argument(
+        '--swears-pad-sec',
+        help='seconds to pad swears (default: 0.0)',
+        type=float,
+        default=0.0,
+        metavar='<pad seconds>',
+        dest="swearsPadSec",
+    )
+    parser.add_argument(
+        '--embed-subs', help='embed cleaned subtitle stream (default: false)', action='store_true', dest="embedSubs"
+    )
+    parser.add_argument(
+        '--full-subs',
+        help='output full subtitle file with swears replaced (default: false, only outputs swear lines)',
+        action='store_true',
+        dest="fullSubs",
+    )
+    parser.add_argument(
+        '--subs-only',
+        help='only generate subtitle file, do not process video (default: false)',
+        action='store_true',
+        dest="subsOnly",
+    )
+    parser.add_argument(
+        '--edl',
+        help='generate EDL file for video editors (also implies --subs-only) (default: false)',
+        action='store_true',
+    )
+    parser.add_argument(
+        '--json',
+        help='generate JSON file detailing edits (default: false)',
+        action='store_true',
+        dest="jsonDump",
+    )
+    parser.add_argument(
+        '--subs-lang',
+        help='subtitle language (default: eng) (append :<index> to force specific stream index, e.g. eng:2)',
+        default=SUBTITLE_DEFAULT_LANG,
+        metavar='<language>',
+        dest="subsLang",
+    )
+    parser.add_argument(
+        '--re-encode-video',
+        help='force re-encode of video stream (default: false)',
+        action='store_true',
+        dest="reEncodeVideo",
+    )
+    parser.add_argument(
+        '--re-encode-audio',
+        help='force re-encode of audio stream (default: false)',
+        action='store_true',
+        dest="reEncodeAudio",
+    )
+    parser.add_argument(
+        '--hard-code',
+        help='hard-code (burn) cleaned subtitles into video stream (implies --re-encode-video) (default: false)',
+        action='store_true',
+        dest="hardCode",
+    )
+    parser.add_argument(
+        '--vparams',
+        help=f'video encoding parameters (default: {VIDEO_DEFAULT_PARAMS}) (prefix with base64: if needed)',
+        default=VIDEO_DEFAULT_PARAMS,
+        metavar='<ffmpeg video args>',
+    )
+    parser.add_argument(
+        '--audio-stream-index',
+        help='audio stream index to process (default: auto-detect if only one stream)',
+        type=int,
+        default=None,
+        metavar='<index>',
+        dest="audioStreamIdx",
+    )
+    parser.add_argument(
+        '--aparams',
+        help=f'audio encoding parameters (default: {AUDIO_DEFAULT_PARAMS}) (prefix with base64: if needed)',
+        default=AUDIO_DEFAULT_PARAMS,
+        metavar='<ffmpeg audio args>',
+    )
+    parser.add_argument(
+        '--audio-downmix',
+        help='downmix audio to stereo if input has more channels (default: false)',
+        action='store_true',
+        dest="aDownmix",
+    )
+    parser.add_argument(
+        '--threads-input',
+        help='set threads for ffmpeg input processing (default: auto)',
+        type=int,
+        default=None,
+        metavar='<threads>',
+        dest="threadsInput",
+    )
+    parser.add_argument(
+        '--threads-encoding',
+        help='set threads for ffmpeg output encoding (default: auto)',
+        type=int,
+        default=None,
+        metavar='<threads>',
+        dest="threadsEncoding",
+    )
+    parser.add_argument(
+        '--offline', help='do not attempt to download subtitles (default: false)', action='store_true'
+    )
+
+    args = parser.parse_args()
+
+    if args.hardCode:
+        args.reEncodeVideo = True
+
+    if not args.output:
+        inParts = os.path.splitext(args.input)
+        args.output = inParts[0] + "_clean" + inParts[1]
+
+    if not args.subs:
+        args.subs = GetSubtitles(args.input, args.subsLang, args.offline)
+
+    cleaner = VidCleaner(
+        args.input,
+        args.subs,
+        args.output,
+        args.subsOut,
+        args.swears,
+        args.swearsPadSec,
+        args.embedSubs,
+        args.fullSubs,
+        args.subsOnly,
+        args.edl,
+        args.jsonDump,
+        args.subsLang,
+        args.reEncodeVideo,
+        args.reEncodeAudio,
+        args.hardCode,
+        args.vparams,
+        args.audioStreamIdx,
+        args.aparams,
+        args.aDownmix,
+        args.threadsInput,
+        args.threadsEncoding,
+        args.plexAutoSkipJson,
+        args.plexAutoSkipId,
+    )
+    cleaner.CreateCleanSubAndMuteList()
+    cleaner.MultiplexCleanVideo()
+
+
+if __name__ == "__main__":
+    RunCleanvid()


### PR DESCRIPTION
Full disclosure, I'm not a programmer, not even a little. Just wanted to try running issue #27 through roocode using gemini pro 2.5 and it worked. But using -filter_script caused ffmpeg to complain that it couldn't even stream copy video even though it was only filtering audio, so to workaround gemini demuxed first, then in a 2nd step only ran the audio through ffmpeg, then remuxed to avoid a video reencode. Because of how much code changed and the quirks that were surely introduced I figured it'd make more sense to mostly leave cleanvid.py alone and just change it to pass arguments to the new cleanvidwin.py file when the user passes --win, so no one whose use cases are working fine are inconvenienced. Cleanvid.py also suggests passing --win during some failed runs and readme.md was updated to show the --win usage.

Finally I noticed this process could caused embedded images in videos (like a movie poster) to get reencoded as a second video stream, our first quirk of the demux/remux strategy. Not all players liked that, so the last commit tries to avoid unembedding and failing that only maps the first video stream back to the output file. 

Although I have run tests, only on windows and only on some similar files. Many possible quirks remain in cases I'm sure I couldn't think of or replicate. I hope the implementation with --win makes it possible to test and fortify this method without much disruption to current happy users while allowing windows users an alternative to the wsl workaround. Hope it helps. Below is gemini's more detailed and technical explanation of the changes. 

# Technical Summary: Windows Compatibility Fix (`--win` Flag)

This document summarizes the technical changes implemented to address errors encountered when running `cleanvid` on Windows, culminating in the introduction of the `--win` flag.

## 1. Original Problem: Windows Command-Line Length Limit

*   **Symptom:** Running `cleanvid.py` on Windows with videos requiring many audio mutes (long subtitle files) resulted in a `FileNotFoundError: [WinError 206] The filename or extension is too long`.
*   **Cause:** The original `cleanvid.py` constructed a single `ffmpeg` command. The audio muting was implemented using the `-filter_complex` argument, joining numerous `afade` filter descriptions into one long string (e.g., `"[0:a:0]afade=...,afade=...,afade=...[a0]"`). On Windows, this string often exceeded the operating system's maximum command-line length.
*   **File Affected:** `src/cleanvid/cleanvid.py` (specifically the `MultiplexCleanVideo` method).

## 2. Initial Fix Attempt: `-filter_script`

*   **Approach:** To avoid the long command line, the `-filter_complex` argument was replaced with `-filter_script`. The complex filter graph string was written to a temporary text file, and `ffmpeg` was instructed to read it using `-filter_script path/to/temp_filter.txt`.
*   **Rationale:** This moved the lengthy filter definition out of the command line itself, successfully bypassing the `WinError 206`.

## 3. Secondary Problem: `ffmpeg` Filter/Copy Conflict

*   **Symptom:** After implementing `-filter_script`, `ffmpeg` produced a new error: `Filtergraph script '...' was specified, but codec copy was selected. Filtering and streamcopy cannot be used together.`
*   **Cause:** Even though the `-filter_script` only targeted the *audio* stream, `ffmpeg` prohibits using *any* stream copying (`-c:v copy` or `-c:a copy`) from an input if *any* filtergraph (`-filter_complex` or `-filter_script`) is applied to *any* stream from that same input. The script was typically using `-c:v copy` to avoid re-encoding the video when only audio changes were needed.
*   **File Affected:** `src/cleanvid/cleanvid.py` (The version modified with `-filter_script`).

## 4. Multi-Step Solution (`cleanvidwin.py`)

*   **Approach:** To resolve the filter/copy conflict without forcing unnecessary video re-encoding, a multi-step `ffmpeg` process was implemented (captured in `src/cleanvid/cleanvidwin.py`):
    1.  **Split:** Extract required streams into temporary files.
        *   `ffmpeg -i input.mp4 -map 0:v -c:v copy temp_video.mkv` (Copy video)
        *   `ffmpeg -i input.mp4 -map 0:a:idx -c:a pcm_s16le temp_audio.wav` (Extract and decode target audio to WAV)
        *   (Potentially extract other streams if needed)
    2.  **Filter Audio:** Apply the filter graph to the temporary raw audio file.
        *   `ffmpeg -i temp_audio.wav -filter_script temp_filter.txt -c:a <codec> [params] filtered_audio.ext` (Apply filter script, re-encode audio with desired codec/params)
    3.  **Mux:** Combine the processed streams back into the final output file.
        *   `ffmpeg -i temp_video.mkv -i filtered_audio.ext [-i clean_subs.srt] ... -map 0:v -map 1:a [-map 2:s] ... -c:v copy -c:a copy [-c:s srt/mov_text] ... output.mp4` (Copy video and filtered audio, potentially embed/copy subtitles)
*   **Rationale:** This isolates the filtering step from the stream copying steps, satisfying `ffmpeg`'s requirements while preserving the original video stream (`-c:v copy` in the first and third steps).
*   **File Affected:** Logic implemented in `src/cleanvid/cleanvidwin.py`.

## 5. Considerations for the Multi-Step Method

While the multi-step approach works, it introduces trade-offs compared to the original single-command method:

*   **Code Complexity:** The Python code in `cleanvidwin.py`'s `MultiplexCleanVideo` is significantly more complex, managing multiple `ffmpeg` processes, temporary files, and intricate argument/mapping logic.
*   **Performance:** Running `ffmpeg` multiple times incurs overhead. Disk I/O for reading/writing large temporary video/audio files can also make this method slower than the original (when the original works).
*   **Field Testing:** This newer method has seen less real-world testing across diverse platforms, `ffmpeg` versions, and complex media files compared to the original logic.
*   **Edge Cases:** While designed to be robust, handling complex scenarios (multiple audio/subtitle tracks needing preservation, unusual codecs, hardcoding subtitles) adds further complexity to the multi-step process and might have undiscovered edge cases.
*   **Disk Space:** Requires temporary disk space for intermediate video, raw audio, and filtered audio files.

## 6. Final Solution: `--win` Flag Integration

Given the trade-offs of the multi-step method, it was decided not to make it the default behavior immediately. Instead, `cleanvid.py` was modified to act as a controller:

*   **`--win` Flag:** A new command-line argument `--win` was added to `cleanvid.py`.
*   **Conditional Logic:**
    *   If `cleanvid.py --win ...` is executed, it uses Python's `subprocess.run` to execute `cleanvidwin.py`, passing all other arguments along. This invokes the multi-step, Windows-compatible method.
    *   If `cleanvid.py` is executed *without* `--win`, it runs its original, single-step `ffmpeg` logic (using `-filter_complex`).
*   **Error Handling:** If the original logic fails with a `ValueError` (the typical exception for `ffmpeg` failures in this script) *and* the OS is detected as Windows, a message is printed to `stderr` suggesting the user try the command again with the `--win` flag.
*   **Benefits:**
    *   Provides a working solution for Windows users encountering command-length errors via the explicit `--win` flag.
    *   Preserves the original, well-tested, and potentially faster behavior as the default for users on other platforms (like Linux) or Windows users not hitting the limits.
    *   Minimizes disruption for existing users.
    *   Offers a clear path to potentially make the multi-step method the default in the future, should extensive testing prove its universal stability and reliability.
*   **Files Affected:** `src/cleanvid/cleanvid.py` (argument parser and main execution logic modified). `src/cleanvid/cleanvidwin.py` (remains the implementation of the multi-step fix). `README.md` (updated usage).

## 7. Tertiary Problem: Extraneous Video Stream (Cover Art)

*   **Symptom:** Files processed using the `--win` flag (multi-step method) sometimes contained an extra, unexpected video stream, often identified as a PNG format by tools like `mediainfo`. This occurred when the original input file had embedded cover art. While playable in some players (VLC), it caused issues in others (Media Player Classic). The original single-step method did not exhibit this behavior.
*   **Cause:** The multi-step process involved splitting the video stream into a temporary file using `ffmpeg -i input.mp4 -map 0:v -c:v copy temp_video.ext`. The `-map 0:v` directive copies *all* streams classified as video from the input. If the input contained embedded cover art (e.g., a PNG or JPG), `ffmpeg` often interpreted this as a secondary video stream and copied it alongside the main video stream into the temporary file. The subsequent muxing step also used `-map 0:v`, copying both the main video and the cover art stream from the temporary file into the final output.
*   **Fix:** The video splitting step in `cleanvidwin.py` was modified:
    1.  The script now attempts to detect the original input container format (e.g., mp4, mkv) using `ffprobe` and uses that format for the temporary video file, aiming to preserve container characteristics.
    2.  Crucially, the `ffmpeg` command for splitting the video was changed from `-map 0:v` to `-map 0:v:0`. This explicitly maps only the *first* video stream from the input file to the temporary file, effectively excluding embedded cover art or other secondary video streams.
*   **Rationale:** By specifically mapping only the primary video stream (`0:v:0`) during the initial split, the temporary video file no longer contains the extraneous cover art stream. The final muxing step therefore only includes the intended video stream, aligning the output structure more closely with the original single-step method and improving compatibility. Using the original container format for the temporary file further attempts to minimize differences introduced by the multi-step process.
*   **Files Affected:** `src/cleanvid/cleanvidwin.py` (logic within `MultiplexCleanVideo` modified).